### PR TITLE
Break orientation into components for consistency.

### DIFF
--- a/docs/SONATA_DEVELOPER_GUIDE.md
+++ b/docs/SONATA_DEVELOPER_GUIDE.md
@@ -548,7 +548,7 @@ For model_processing=*"fullaxon"*, the biophysical neuron will construct and sim
 
 **x, y, z** - position of the soma in world coordinates.
 
-**orientation** [4 FLOAT] - (w, x, y, z) quaternion with the local to world rotation of the morphology around the soma center.
+**orientation_[w|x|y|z]** - quaternion with the local to world rotation of the morphology around the soma center.
 
 To place morphologies in world coordinates, a translation is applied first to move each morphology's soma center to (0, 0, 0) in its local coordinates system.
 Then, the rotation implied by this quaternion is applied to the morphology.


### PR DESCRIPTION
All positions are already specified as one-dimensional datasets, thus
orientation of the nodes should follow this example. As an added
benefit, this will make the order of components (namely 'w' first or
last) completely unambiguous.